### PR TITLE
prevent forced Int conversion (results in 0 instead of null)

### DIFF
--- a/src/ink/runtime/Path.hx
+++ b/src/ink/runtime/Path.hx
@@ -188,8 +188,7 @@ class Path extends RObject implements IEquatable//<Path>
 
 		var componentStrings = componentsStr.split('.');
 		for (str in componentStrings) {
-			var index:Int;
-			index = Std.parseInt(str);
+			var index = Std.parseInt(str);
 			if ( LibUtil.validInt(index) ) {  //int.TryParse (str , out index)
 				components.push ( Component.createFromIndex(index));
 			} else {

--- a/src/ink/runtime/Story.hx
+++ b/src/ink/runtime/Story.hx
@@ -339,7 +339,7 @@ class Story extends RObject
 
             var count:Int = 0;
             var containerPathStr = container.path.toString();
-            var tryCount:Int = state.visitCounts.get(containerPathStr);  //TryGetValue (containerPathStr, out count);
+            var tryCount = state.visitCounts.get(containerPathStr);  //TryGetValue (containerPathStr, out count);
 			if ( LibUtil.validInt(tryCount) ) {
 				count = tryCount;
 			}
@@ -350,7 +350,7 @@ class Story extends RObject
         {
             var count = 0;
             var containerPathStr = container.path.toString();
-			 var tryCount:Int = state.visitCounts.get(containerPathStr);  //TryGetValue (containerPathStr, out count);
+			 var tryCount = state.visitCounts.get(containerPathStr);  //TryGetValue (containerPathStr, out count);
 			if ( LibUtil.validInt(tryCount) ) {
 				count = tryCount;
 			}
@@ -371,9 +371,8 @@ class Story extends RObject
                 ErrorThrow ("TURNS_SINCE() for target ("+container.name+" - on "+container.debugMetadata+") unknown. The story may need to be compiled with countAllVisits flag (-c).");
             }
 
-            var index:Int = 0;
             var containerPathStr = container.path.toString();
-			index = state.turnIndices.get(containerPathStr);  //state.turnIndices.TryGetValue (containerPathStr, out index)
+			var index = state.turnIndices.get(containerPathStr);  //state.turnIndices.TryGetValue (containerPathStr, out index)
             if ( LibUtil.validInt(index) ) {
                 return state.currentTurnIndex - index;
             } else {

--- a/src/ink/runtime/StoryState.hx
+++ b/src/ink/runtime/StoryState.hx
@@ -55,8 +55,7 @@ class StoryState
 	/// the specific knot or stitch.</param>
 	public function VisitCountAtPathString( pathString:String):Int
 	{
-		var visitCountOut:Int;
-		visitCountOut = visitCounts.get(pathString);  // tocheck:, StringMap for int... does return null for Flash target
+		var visitCountOut = visitCounts.get(pathString);  // tocheck:, StringMap for int... does return null for Flash target
 		if ( LibUtil.validInt(visitCountOut)  ) //visitCounts.TryGetValue (pathString, out visitCountOut))  //visitCountOut != null
 			return visitCountOut;
 


### PR DESCRIPTION
(Sorry, i deleted the branch i cherry picked from and the old PR was closed by accident somehow)

```haxe
var foo: Int = Std.parseInt('not_an_int'); 
```
will result in foo being `0` instead of `null` on static targets, see last paragraph [in the manual](https://haxe.org/manual/types-nullability.html).
This in turn will make `LibUtil.validInt()` fail and `Path.set_componentsString()` choose the wrong branch [here](https://github.com/Glidias/inkhaxe/blob/master/src/ink/runtime/Path.hx#L193). This PR should fix all static haxe targets.

I was able to load and run the provided `tros.ink.json` file.